### PR TITLE
Support Keycloak version 20+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <keycloak.version>10.0.2</keycloak.version>
+        <keycloak.version>20.0.0</keycloak.version>
         <junit.version>4.13.1</junit.version>
     </properties>
 
@@ -60,6 +60,11 @@
             <artifactId>keycloak-services</artifactId>
             <version>${keycloak.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-crypto-default</artifactId>
+            <version>${keycloak.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/be/cronos/keycloak/policy/Argon2VariantPasswordPolicyProviderFactory.java
+++ b/src/main/java/be/cronos/keycloak/policy/Argon2VariantPasswordPolicyProviderFactory.java
@@ -2,6 +2,7 @@ package be.cronos.keycloak.policy;
 
 import be.cronos.keycloak.enums.Argon2Variant;
 import org.keycloak.policy.PasswordPolicyConfigException;
+import org.keycloak.policy.PasswordPolicyProvider;
 
 /**
  * @author <a href="mailto:dries.eestermans@is4u.be">Dries Eestermans</a>
@@ -32,4 +33,9 @@ public class Argon2VariantPasswordPolicyProviderFactory extends Argon2GenericPol
         return String.valueOf(DEFAULT_ARGON2_VARIANT);
     }
 
+
+    @Override
+    public String getConfigType() {
+        return PasswordPolicyProvider.STRING_CONFIG_TYPE;
+    }
 }


### PR DESCRIPTION
This PR contains the necessary changes to make this provider work with Keycloak >= 20.0 (as of 2022-11). 